### PR TITLE
Remove mentions of Google in the plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Google Authenticator for WordPress
+Authenticator for WordPress
 ==================================
 
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/julien731/WP-Google-Authenticator/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/julien731/WP-Google-Authenticator/?branch=master)
@@ -6,8 +6,6 @@ Google Authenticator for WordPress
 If you are concerned about security, you should look into 2-factor authentication.
 
 *Quick reminder:* 2-factor authentication adds an extra layer of security by requesting a one time password in addition to standard username / password credentials.
-
-This plugin uses the Google Authenticator app. I bet you know Google, and you probably know they have some good products out there. Google Authenticator is one of them.
 
 [Download the Google Authenticator app](https://support.google.com/accounts/answer/1066447?hl=en) on your phone (iPhone, Android or Blackberry). Install this plugin on your site. After activating it and generating a secret key, you will be able to add the site to your app by scanning a QR code. That's it!
 
@@ -29,7 +27,8 @@ What the plugin does:
 - Recovery code in case the user can't use the app
 
 ### Using Authy
-You're using [Authy](https://www.authy.com/)? Google Authenticator for WordPress is fully compatible with Authy. You can add the 2-steps authentication and use Authy to generate the one time password.
+
+You're using [Authy](https://www.authy.com/)? Authenticator for WordPress is fully compatible with Authy. You can add the 2-steps authentication and use Authy to generate the one time password.
 
 ## Changelog ##
 

--- a/wp-google-authenticator.php
+++ b/wp-google-authenticator.php
@@ -196,9 +196,9 @@ if ( ! class_exists( 'WP_Google_Authenticator' ) ):
 		private function setup_constants() {
 			define( 'WPGA_VERSION', '1.1.0' );
 			define( 'WPGA_DB_VERSION', '1' );
-			define( 'WPGA_NAME', 'WP Google Authenticator' );
+			define( 'WPGA_NAME', 'WP Authenticator' );
 			define( 'WPGA_AUTHOR', 'Julien Liabeuf' );
-			define( 'WPGA_URI', 'http://julienliabeuf.com' );
+			define( 'WPGA_URI', 'https://julienliabeuf.com' );
 			define( 'WPGA_URL', plugin_dir_url( __FILE__ ) );
 			define( 'WPGA_PATH', plugin_dir_path( __FILE__ ) );
 			define( 'WPGA_ROOT', trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) );

--- a/wp-google-authenticator.php
+++ b/wp-google-authenticator.php
@@ -7,9 +7,9 @@
  * @copyright 2016 Julien Liabeuf
  *
  * @wordpress-plugin
- * Plugin Name:       WP Google Authenticator
+ * Plugin Name:       WP Authenticator
  * Plugin URI:        https://wordpress.org/plugins/wp-google-authenticator/
- * Description:       WP Google Authenticator provides a safe way to add 2-factor authentication to your WordPress site using the Google 2FA system with the Google Authenticator app.
+ * Description:       WP Authenticator provides a safe way to add 2-factor authentication to your WordPress site using the Google 2FA system with the Google Authenticator app.
  * Version:           1.1.0
  * Author:            Julien Liabeuf
  * Author URI:        https://julienliabeuf.com


### PR DESCRIPTION
# What Happened

The plugin got suspended on WordPress.org because of copyright issues with the term Google in the plugin name. This PR removes all the mentions.

# Insights

Removed "Google" from the plugin name and from a few places in the readme.