### PR TITLE
Contextual help deprecated

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,24 +1,23 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "05c4740bd9688b914a4039e304b77cb1",
     "content-hash": "74b82c97a6218853ebdff019f454ba00",
     "packages": [
         {
             "name": "julien731/wp-dismissible-notices-handler",
-            "version": "1.0.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/julien731/WP-Dismissible-Notices-Handler.git",
-                "reference": "85ce1debbdfd4543e5b835dfe6670b9de99ddf6b"
+                "reference": "062b1472ddbac450f87a85fc4b979e04cde3a344"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/julien731/WP-Dismissible-Notices-Handler/zipball/85ce1debbdfd4543e5b835dfe6670b9de99ddf6b",
-                "reference": "85ce1debbdfd4543e5b835dfe6670b9de99ddf6b",
+                "url": "https://api.github.com/repos/julien731/WP-Dismissible-Notices-Handler/zipball/062b1472ddbac450f87a85fc4b979e04cde3a344",
+                "reference": "062b1472ddbac450f87a85fc4b979e04cde3a344",
                 "shasum": ""
             },
             "require": {
@@ -27,7 +26,8 @@
             "type": "library",
             "autoload": {
                 "files": [
-                    "handler.php"
+                    "handler.php",
+                    "includes/helper-functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -44,7 +44,11 @@
             ],
             "description": "A simple library to handle Ajax-dismissible admin notices for WordPress",
             "homepage": "https://github.com/julien731/WP-Dismissible-Notices-Handler",
-            "time": "2016-04-03 05:12:27"
+            "support": {
+                "issues": "https://github.com/julien731/WP-Dismissible-Notices-Handler/issues",
+                "source": "https://github.com/julien731/WP-Dismissible-Notices-Handler/tree/1.2.2"
+            },
+            "time": "2021-02-17T15:56:18+00:00"
         }
     ],
     "packages-dev": [],
@@ -54,5 +58,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -89,17 +89,17 @@ final class WPGA_Settings {
 	 */
 	function network_settings_page() {
 
-		// Standalone site menu
-		if ( true === is_multisite() && false === WPGA()->is_network_enabled() ) {
-			add_submenu_page( 'options-general.php', sprintf( esc_html__( '%1$s Settings', 'wpga' ), WPGA_NAME ), esc_html__( 'Authenticator', 'wpga' ), 'administrator', 'wpga-settings', array(
+		// Network admin menu.
+		if ( true === is_multisite() && true === WPGA()->is_network_enabled() ) {
+			add_submenu_page( 'settings.php', esc_html__( 'Authenticator Network Settings', 'wpga' ), esc_html__( 'Authenticator', 'wpga' ), 'administrator', 'wpga-settings', array(
 				$this,
 				'settings_page',
 			) );
 		}
 
-		// Network admin menu
+		// Standalone admin menu.
 		else {
-			add_submenu_page( 'settings.php', esc_html__( 'Authenticator Network Settings', 'wpga' ), esc_html__( 'Authenticator', 'wpga' ), 'administrator', 'wpga-settings', array(
+			add_submenu_page( 'options-general.php', sprintf( esc_html__( '%1$s Settings', 'wpga' ), WPGA_NAME ), esc_html__( 'Authenticator', 'wpga' ), 'administrator', 'wpga-settings', array(
 				$this,
 				'settings_page',
 			) );

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -91,7 +91,7 @@ final class WPGA_Settings {
 
 		// Network admin menu.
 		if ( true === is_multisite() && true === WPGA()->is_network_enabled() ) {
-			add_submenu_page( 'settings.php', esc_html__( 'Authenticator Network Settings', 'wpga' ), esc_html__( 'Authenticator', 'wpga' ), 'administrator', 'wpga-settings', array(
+			$menu_page = add_submenu_page( 'settings.php', esc_html__( 'Authenticator Network Settings', 'wpga' ), esc_html__( 'Authenticator', 'wpga' ), 'administrator', 'wpga-settings', array(
 				$this,
 				'settings_page',
 			) );
@@ -99,11 +99,14 @@ final class WPGA_Settings {
 
 		// Standalone admin menu.
 		else {
-			add_submenu_page( 'options-general.php', sprintf( esc_html__( '%1$s Settings', 'wpga' ), WPGA_NAME ), esc_html__( 'Authenticator', 'wpga' ), 'administrator', 'wpga-settings', array(
+			$menu_page = add_submenu_page( 'options-general.php', sprintf( esc_html__( '%1$s Settings', 'wpga' ), WPGA_NAME ), esc_html__( 'Authenticator', 'wpga' ), 'administrator', 'wpga-settings', array(
 				$this,
 				'settings_page',
 			) );
 		}
+
+		// Adds my_help_tab when my_admin_page loads
+		add_action( 'load-' . $menu_page, 'wpga_contextual_help' );
 
 	}
 

--- a/includes/admin/functions-misc.php
+++ b/includes/admin/functions-misc.php
@@ -100,13 +100,12 @@ function wpga_force_set_secret() {
 
 }
 
-add_filter( 'contextual_help', 'wpga_contextual_help', 10, 3 );
 /**
  * Register the contextual help for the plugin admin screen
  */
 function wpga_contextual_help() {
 
-	if ( ! isset( $_GET['page'] ) || $_GET['page'] != 'wpga_options' ) {
+	if ( ! isset( $_GET['page'] ) || $_GET['page'] != 'wpga-settings' ) {
 		return;
 	}
 

--- a/includes/admin/views/options/option-user-roles.php
+++ b/includes/admin/views/options/option-user-roles.php
@@ -19,7 +19,7 @@
 function wpga_option_callback_user_roles( $option ) {
 
 	$option_id      = esc_attr( $option['id'] );
-	$value          = WPGA()->settings->get_option( $option_id );
+	$value          = WPGA()->settings->get_option( $option_id, array() );
 	$status         = WPGA()->settings->get_option( 'user_role_status', 'all' );
 	$checked_all    = ( 'all' === $status ) ? 'checked="checked"' : '';
 	$checked_custom = ( 'custom' === $status ) ? 'checked="checked"' : '';


### PR DESCRIPTION
# What Happened

The plugin used a deprecated method for adding contextual help menus.

# Insights

- Updated to the current way for registering contextual help
- Fixed an issue with the settings screen
- Fixed an issue with the roles setting