### PR TITLE
Sanitize inputs before use

### DIFF
--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -440,7 +440,9 @@ final class WPGA_Settings {
 	 */
 	public function settings_page() {
 
-		if ( isset( $_GET['updated'] ) && 'true' === $_GET['updated'] && is_network_admin() ) { ?>
+		$updated = filter_input( INPUT_GET, 'updated', FILTER_SANITIZE_STRING );
+
+		if ( isset( $_GET['updated'] ) && 'true' === $updated && is_network_admin() ) { ?>
 			<div id="setting-error-settings_updated" class="updated settings-error notice is-dismissible">
 				<p><strong>Settings saved.</strong></p><button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button>
 			</div>

--- a/includes/admin/functions-misc.php
+++ b/includes/admin/functions-misc.php
@@ -30,7 +30,7 @@ function wpga_admin_notices() {
 		return;
 	}
 
-	$uid = isset( $_GET['user_id'] ) ? $_GET['user_id'] : '';
+	$uid = isset( $_GET['user_id'] ) ? filter_input( INPUT_GET, 'user_id', FILTER_SANITIZE_NUMBER_INT ) : '';
 
 	$messages = array(
 		'10' => esc_html__( 'Your secret key has been regenerated.', 'wpga' ),
@@ -38,13 +38,15 @@ function wpga_admin_notices() {
 		'12' => sprintf( esc_html__( 'The attempts count has been reset.', 'wpga' ), $uid ),
 	);
 
-	if ( ! isset( $messages[ $_GET['update'] ] ) ) {
+	$update = filter_input( INPUT_GET, 'update', FILTER_SANITIZE_STRING );
+
+	if ( ! isset( $messages[ $update ] ) ) {
 		return;
 	}
 
 	?>
 	<div class="updated">
-		<p><?php echo esc_html( $messages[ $_GET['update'] ] ); ?></p>
+		<p><?php echo esc_html( $messages[ $update ] ); ?></p>
 	</div>
 	<?php
 

--- a/includes/admin/functions-secret.php
+++ b/includes/admin/functions-secret.php
@@ -68,6 +68,8 @@ function wpga_edit_secret() {
 		return;
 	}
 
+	$user_id = filter_input( INPUT_GET, 'user_id', FILTER_SANITIZE_NUMBER_INT );
+
 	switch( $_GET['action'] ):
 
 		case 'regenerate':
@@ -97,9 +99,9 @@ function wpga_edit_secret() {
 				return;
 			}
 
-			delete_user_meta( $_GET['user_id'], 'wpga_secret' );
-			delete_user_meta( $_GET['user_id'], 'wpga_backup_key' );
-			wp_redirect( add_query_arg( array( 'user_id' => $_GET['user_id'], 'update' => '11' ), admin_url( 'user-edit.php' ) ) );
+			delete_user_meta( $user_id, 'wpga_secret' );
+			delete_user_meta( $user_id, 'wpga_backup_key' );
+			wp_redirect( add_query_arg( array( 'user_id' => $user_id, 'update' => '11' ), admin_url( 'user-edit.php' ) ) );
 			exit;
 
 			break;
@@ -110,13 +112,13 @@ function wpga_edit_secret() {
 				return;
 			}
 
-			if ( ! current_user_can( 'edit_user', $_GET['user_id'] ) ) {
+			if ( ! current_user_can( 'edit_user', $user_id ) ) {
 				return;
 			}
 
-			delete_user_meta( $_GET['user_id'], 'wpga_attempts' );
-			delete_user_meta( $_GET['user_id'], 'wpga_backup_key' );
-			wp_redirect( add_query_arg( array( 'user_id' => $_GET['user_id'], 'update' => '12' ), admin_url( 'user-edit.php' ) ) );
+			delete_user_meta( $user_id, 'wpga_attempts' );
+			delete_user_meta( $user_id, 'wpga_backup_key' );
+			wp_redirect( add_query_arg( array( 'user_id' => $user_id, 'update' => '12' ), admin_url( 'user-edit.php' ) ) );
 			exit;
 
 			break;

--- a/includes/admin/functions-user-profile.php
+++ b/includes/admin/functions-user-profile.php
@@ -33,7 +33,7 @@ function wpga_user_profile_fields( $user ) {
 	$backup = get_user_meta( $user->ID, 'wpga_backup_key', true );
 
 	if ( isset( $_GET['user_id'] ) ) {
-		$args['user_id'] = (int) $_GET['user_id'];
+		$args['user_id'] = filter_input( INPUT_GET, 'user_id', FILTER_SANITIZE_NUMBER_INT );
 	}
 
 	$regenerate = wp_nonce_url( add_query_arg( $args, admin_url( 'profile.php' ) ), 'regenerate_key' );
@@ -138,7 +138,7 @@ function wpga_admin_custom_profile_fields() {
 		return;
 	}
 
-	$user_id      = (int) $_GET['user_id'];
+	$user_id      = filter_input( INPUT_GET, 'user_id', FILTER_SANITIZE_NUMBER_INT );
 	$secret       = esc_attr( get_user_meta( $user_id, 'wpga_secret', true ) );
 	$args         = array( 'action' => 'revoke', 'user_id' => $user_id );
 	$rst_arg      = array( 'action' => 'reset', 'user_id' => $user_id );

--- a/includes/functions-apps-passwords.php
+++ b/includes/functions-apps-passwords.php
@@ -219,9 +219,12 @@ function wpas_apps_passwords_actions() {
 
 	if ( isset( $_GET['action'] ) && isset( $_GET['wpga_nonce'] ) ) {
 
-		if ( wp_verify_nonce( $_GET['wpga_nonce'], 'wpga_action' ) ) {
+		$action = filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING );
+		$nonce = filter_input( INPUT_GET, 'wpga_nonce', FILTER_SANITIZE_STRING );
 
-			switch ( $_GET['action'] ) {
+		if ( wp_verify_nonce( $nonce, 'wpga_action' ) ) {
+
+			switch ( $action ) {
 				case 'delete':
 
 					if ( isset( $_GET['key'] ) ) {

--- a/includes/scripts-styles.php
+++ b/includes/scripts-styles.php
@@ -23,7 +23,9 @@ function wpga_load_admin_scripts() {
 
 	global $pagenow;
 
-	if ( 'profile.php' === $pagenow || isset( $_GET['page'] ) && in_array( $_GET['page'], array( 'wpga_apps_passwords', 'wpga-settings' ) ) ) {
+	$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+
+	if ( 'profile.php' === $pagenow || isset( $_GET['page'] ) && in_array( $page, array( 'wpga_apps_passwords', 'wpga-settings' ) ) ) {
 		wp_enqueue_script( 'wpga-custom', WPGA_URL . 'assets/js/custom.js', array(), WPGA_VERSION, true );
 		wp_enqueue_script( 'wpga-qrcode', WPGA_URL . 'assets/js/jquery-qrcode.min.js', array( 'jquery' ), '0.14.0', true );
 	}


### PR DESCRIPTION
# What Happened

Not all user data was sanitized before being used. This PR goes through all the places where data that could be misused was not properly handled.

# Insights

Used PHP's [`filter_input()`](https://www.php.net/manual/en/function.filter-input.php) before using any `POST` or `GET` variable.